### PR TITLE
Fix autosave

### DIFF
--- a/packages/components/timed-text-editor/index.js
+++ b/packages/components/timed-text-editor/index.js
@@ -265,6 +265,7 @@ class TimedTextEditor extends React.Component {
         title
       );
 
+      clearTimeout(this.saveTimer);
       this.props.handleAutoSaveChanges(data);
     });
   };
@@ -289,6 +290,7 @@ class TimedTextEditor extends React.Component {
           title
         );
 
+        clearTimeout(this.saveTimer);
         this.props.handleAutoSaveChanges(data);
       }
     );

--- a/packages/components/timed-text-editor/index.js
+++ b/packages/components/timed-text-editor/index.js
@@ -621,8 +621,7 @@ TimedTextEditor.propTypes = {
   timecodeOffset: PropTypes.number,
   handleAnalyticsEvents: PropTypes.func,
   showSpeakers: PropTypes.bool,
-  showTimecodes: PropTypes.bool,
-  fileName: PropTypes.string
+  showTimecodes: PropTypes.bool
 };
 
 export default TimedTextEditor;


### PR DESCRIPTION
**Describe what the PR does**    
<!-- _A clear and concise description of what the PR does. Feel free to use bulletpoints and checkboxes if needed [...]_ -->
This PR fixes autosave-handling. A recent PR introduced autosaving operations on special occasions, e.g. splitting paragraphs. If the document was however modified regularly (inserting/deleting characters) within the last second before splitting a paragraph, the deferred call to autosave emitted a document state that did not include the split paragraph.