### PR TITLE
Fix crash with empty blocks

### DIFF
--- a/packages/components/timed-text-editor/UpdateTimestamps/index.js
+++ b/packages/components/timed-text-editor/UpdateTimestamps/index.js
@@ -48,7 +48,7 @@ const createContentFromEntityList = (currentContent, newEntities) => {
       data: {
         speaker: speaker,
         words: blockEntites,
-        start: blockEntites[0].start
+        start: blockEntites.length > 0 ? blockEntites[0].start : 0
       },
       entityRanges: generateEntitiesRanges(blockEntites, 'punct'),
     };

--- a/packages/components/timed-text-editor/index.js
+++ b/packages/components/timed-text-editor/index.js
@@ -138,8 +138,10 @@ class TimedTextEditor extends React.Component {
         blockIdx < currentContent.blocks.length;
         blockIdx++
       ) {
-        blockMap[currentContent.blocks[blockIdx].key] =
-          updatedContentBlocks.blocks[blockIdx].key;
+        if (updatedContentBlocks.blocks[blockIdx]) {
+          blockMap[currentContent.blocks[blockIdx].key] =
+            updatedContentBlocks.blocks[blockIdx].key;
+        }
       }
 
       const selection = selectionState.merge({


### PR DESCRIPTION
Timestamp realignment crashes the editor when there are empty blocks in the current document.