### PR TITLE
Track segmentation without speaker change

### DIFF
--- a/packages/stt-adapters/bbc-kaldi/group-words-by-speakers.js
+++ b/packages/stt-adapters/bbc-kaldi/group-words-by-speakers.js
@@ -25,6 +25,9 @@ function addSpeakerToEachWord(words, segments) {
     const tmpSpeakerSegment = findSegmentForWord(word, segments);
 
     word.speaker = formatSpeakerName(tmpSpeakerSegment.speaker);
+    // Attach segment start time to force separate paragraphs for distinct segments
+    // even if the assigned speaker name is exactly the same.
+    word.segmentStart = tmpSpeakerSegment.start !== undefined ? tmpSpeakerSegment.start : 'unknown';
     tmpWordsWithSpeakers.push(word);
   });
 
@@ -39,20 +42,22 @@ function addSpeakerToEachWord(words, segments) {
  */
 function groupWordsBySpeaker(wordsWithSpeakers) {
   let currentSpeaker = wordsWithSpeakers[0].speaker;
+  let currentSegmentStart = wordsWithSpeakers[0].segmentStart;
   const results = [ ];
   let paragraph = { words: [], text: '', speaker: currentSpeaker };
   wordsWithSpeakers.forEach((word) => {
-    // if current speaker same as word speaker add words to paragraph
-    if (currentSpeaker === word.speaker) {
+    // if current speaker same as word speaker AND segment start is the same, add words to paragraph
+    if (currentSpeaker === word.speaker && currentSegmentStart === word.segmentStart) {
       paragraph.words.push(word);
       paragraph.text += word.punct + ' ';
       paragraph.speaker = currentSpeaker;
     }
-    // if it's not same speaker
+    // if it's not same speaker or a new segment started
     else {
       paragraph.text = paragraph.text.trim();
       results.push(paragraph);
       currentSpeaker = word.speaker;
+      currentSegmentStart = word.segmentStart;
        paragraph = {
         words: [word],
         text: word.punct + ' ',


### PR DESCRIPTION
Google STT provides us with good segmentation even if speaker diarization is not supported in a model. What happens in the current implementation is that when the speaker doesn't change it all gets grouped into one giant paragraph with all the transcription text.

This MR now creates new paragraphs if the segment changes even if the speaker is the same.

As far as I can assess, this change contains the risk that some STT provider or other google model we may want to use at some point provides weird segmentation and we create a new paragraph for every word or something like that where the previous implementation would have merged it all into one. Neither is great, but currently as I see it, creating new paragraphs on segment change makes for a much cleaner transcript without diarization.

This MR here is actually preparing for, and was implemented in conjunction with, an update to STT v2 API in QDAcity so we can use newer models and support an incredibly large number of languages to transcribe